### PR TITLE
Update non-default listener rule with target group

### DIFF
--- a/.github/scripts/modify_alb_listener.py
+++ b/.github/scripts/modify_alb_listener.py
@@ -14,6 +14,15 @@ frontend_load_balancer_arn = [lb for lb in load_balancers if lb["LoadBalancerNam
 listeners = client.describe_listeners(LoadBalancerArn=frontend_load_balancer_arn)["Listeners"]
 frontend_https_listener_arn = [li for li in listeners if alb_name in li["ListenerArn"]][0]["ListenerArn"]
 
+listener_rules = client.describe_rules(ListenerArn=frontend_https_listener_arn)["Rules"]
+
+# Retrieve all listener rules for ALB that are not default
+listener_rule_arns = []
+for lr in listener_rules:
+    if not lr["IsDefault"]:
+        arn = lr.get("RuleArn")
+        listener_rule_arns.append(arn)
+
 if service_to_deploy == "ServiceUnavailable":
     target_group_prefix = "tdr-su-"
 else:
@@ -22,13 +31,14 @@ else:
 target_groups = client.describe_target_groups()["TargetGroups"]
 target_group = [tg for tg in target_groups if tg["TargetGroupName"].startswith(target_group_prefix)][0]
 
-default_action = {
+change_target_group_action = {
     "Type": "forward",
-    "TargetGroupArn": target_group["TargetGroupArn"]
+    "TargetGroupArn": f"{target_group["TargetGroupArn"]}"
 }
-response = client.modify_listener(
-    ListenerArn=frontend_https_listener_arn,
-    Port=443,
-    Protocol="HTTPS",
-    DefaultActions=[default_action]
-)
+
+#Update non-default listener rules with the new target group
+for lra in listener_rule_arns:
+    response = client.modify_rule(
+        RuleArn=lra,
+        Actions=[change_target_group_action]
+    )

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## TDR Service Unavailable Page
+# TDR Service Unavailable Page
 
-This is the repository for the service unavailable page and the Jenkins files to deploy it. It's split into the following sections.
+This is the repository for the service unavailable page. It's split into the following sections.
 
 `css-src/` The sass files used to build the css. This is copied from the front end
 
@@ -18,7 +18,9 @@ This is the repository for the service unavailable page and the Jenkins files to
 
 `.github/workflows/test.yml` Runs the tests for branch builds.
 
-`.github/workflows/run.yml` Switches the load balancer listener to either the front end target group or the service unavailable target group depending on the parameters.
+`.github/workflows/run.yml` Switches the load balancer listener non-default rule(s) to either the front end target group or the service unavailable target group depending on the parameters.
+
+## Static Page HTML
 
 ### Running it locally
 1. You need to be running python 3
@@ -44,3 +46,21 @@ python3 run_locally.py
 
 The page will be available on `http://localhost:8080`
 
+## Deployment
+
+Run the GitHub action to deploy to the relevant environment.
+
+### Deploying Locally
+
+1. Add relevant AWS credentials with permission to modify load balancer listener
+2. Add `boto3` to the `requirements-runtime.txt`
+3. Set up python virtual environment:
+   ```bash
+         python3 -m venv venv
+         source venv/bin/activate
+         pip install -r requirements.txt            
+     ```
+4. Run the deployment python script:
+   ```bash
+      python3 ./.github/scripts/modify_alb_listener.py
+   ```


### PR DESCRIPTION
To redirect traffic to the relevant target group the non-default listener rule(s) need to be updated with the target group arn

The default target group rule is not updated

Unclear how this was working previously